### PR TITLE
Fix nondeterministic test

### DIFF
--- a/core/src/main/java/ma/glasnost/orika/metadata/ClassMapBuilderForMaps.java
+++ b/core/src/main/java/ma/glasnost/orika/metadata/ClassMapBuilderForMaps.java
@@ -24,7 +24,7 @@ import ma.glasnost.orika.PropertyNotFoundException;
 import ma.glasnost.orika.property.PropertyResolverStrategy;
 
 import java.util.HashSet;
-import java.util.LinkedHashSet;
+import java.util.TreeSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -112,10 +112,10 @@ public class ClassMapBuilderForMaps<A, B> extends ClassMapBuilder<A,B> {
     	
     	Set<String> remainingProperties;
     	if (isATypeBean()) {
-            remainingProperties = new LinkedHashSet<>(getPropertiesForTypeA());
+            remainingProperties = new TreeSet<>(getPropertiesForTypeA());
             remainingProperties.removeAll(getMappedPropertiesForTypeA());
         } else {
-    	    remainingProperties = new LinkedHashSet<>(getPropertiesForTypeB());
+    	    remainingProperties = new TreeSet<>(getPropertiesForTypeB());
     	    remainingProperties.removeAll(getMappedPropertiesForTypeB());
     	}  
     	remainingProperties.remove("class");

--- a/core/src/test/java/ma/glasnost/orika/test/generator/BeanToListGenerationTestCase.java
+++ b/core/src/test/java/ma/glasnost/orika/test/generator/BeanToListGenerationTestCase.java
@@ -69,8 +69,8 @@ public class BeanToListGenerationTestCase {
 		Assert.assertEquals(student.grade.percentage, result.get(++index));
 		Assert.assertEquals(student.name.first, result.get(++index));
 		Assert.assertEquals(student.name.last, result.get(++index));
-		Assert.assertEquals(student.id, result.get(++index));
 		Assert.assertEquals(student.email, result.get(++index));
+		Assert.assertEquals(student.id, result.get(++index));
 		
 		
 		Student mapBack = mapper.map(result, Student.class);


### PR DESCRIPTION
## Description

When running the test, `BeanToListGenerationTestCase#testBeanToListGeneration`, there is the potential for nondeterministic behavior due to the unspecified order of the values returned from `getPropertiesForType`.

Running the test:

```shell
mvn install -pl core test -Dtest='ma.glasnost.orika.test.generator.BeanToListGenerationTestCase#testBeanToListGeneration'
```

The potential error (with differences denoted between square brackets):

```shell
org.junit.ComparisonFailure: expected:<[1]> but was:<[test@test.com]>                                                                   
        at ma.glasnost.orika.test.generator.BeanToListGenerationTestCase.testBeanToListGeneration(BeanToListGenerationTestCase.java:72)
```

## Proposed Changes

Currently, the values returned from `getPropertiesForType` are placed in a `LinkedHashSet`, which then retains the order of the returned values, but doesn't impose an ordering on the returned values. The `LinkedHashSet` is replaced with a `TreeSet` which will sort the properties and maintain that the order is always consistent across executions.

Ideally, the solution would be applied directly (and only) to the test code, but in this situation, it seems the best approach is to apply this change to the `ClassMapBuilderForMaps` and increase the consistency of the generated code/objects.